### PR TITLE
Adding failure-capture information to exception message.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /tmp/
 .tags
 .DS_Store
+/.idea/

--- a/lib/svelte/errors/version_error.rb
+++ b/lib/svelte/errors/version_error.rb
@@ -2,8 +2,14 @@ module Svelte
   # Svelte error class to represent version errors.
   # Raised when a Swagger v1 JSON is fed into Svelte
   class VersionError < StandardError
-    def message
-      'Invalid Swagger version spec supplied. Svelte supports Swagger v2 only'
+
+    def initialize(supplied_version)
+      @supplied_version = supplied_version
     end
+
+    def message
+      %-"swagger" field is #{@supplied_version or 'empty'}. Svelte only supports Swagger v2.0.-
+    end
+
   end
 end

--- a/lib/svelte/swagger_builder.rb
+++ b/lib/svelte/swagger_builder.rb
@@ -68,8 +68,9 @@ module Svelte
     end
 
     def validate_version
-      if raw_hash['swagger'] != '2.0'
-        raise VersionError
+      swagger_version = raw_hash['swagger']
+      if swagger_version != '2.0'
+        raise VersionError.new(swagger_version)
       end
     end
 

--- a/spec/lib/svelte_spec.rb
+++ b/spec/lib/svelte_spec.rb
@@ -148,7 +148,7 @@ describe Svelte do
       it 'raises a VersionError exception' do
         expect { described_class.create(json: json, module_name: module_name) }
           .to raise_error(Svelte::VersionError,
-                          'Invalid Swagger version spec supplied. Svelte supports Swagger v2 only')
+                          '"swagger" field is empty. Svelte only supports Swagger v2.0.')
       end
     end
   end


### PR DESCRIPTION
@AgentAntelope @brafales @AdColvinNOTHS I thought I'd do a quick bit of lunchtime ruby!

One thing I always find useful is capturing the values of parameters that lead to an exception in its message.  This greatly helps a developer faced with this exception.

I have no doubt that my implementation is not idiomatic ruby, so I'm prepared for comments or all out rejection. :-)
