### PR TITLE
add support for specifying Faraday Middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /tmp/
 .tags
 .DS_Store
+.byebug_history

--- a/lib/svelte.rb
+++ b/lib/svelte.rb
@@ -25,13 +25,23 @@ require 'svelte/generic_operation'
 #   Svelte::Service::Comments::Api::Comments.create_comment(contents: 'nice post!')
 #   Svelte::Service::Comments::Api::Comments.delete_comment_by_id(id: 10)
 module Svelte
-  # @param url [String] url pointing to a Swagger spec
-  # @param json [String] the entire Swagger spec as a String
-  # @param module_name [String] constant name where you want Svelte to build
-  #   the new functionality on top of
-  # @note Either `url` or `json` need to be provided. `url` will take
-  #   precedence over `json`
-  def self.create(url: nil, json: nil, module_name:, options: {})
-    Service.create(url: url, json: json, module_name: module_name, options: options)
+  class<< self
+    # @param url [String] url pointing to a Swagger spec
+    # @param json [String] the entire Swagger spec as a String
+    # @param module_name [String] constant name where you want Svelte to build
+    #   the new functionality on top of
+    # @note Either `url` or `json` need to be provided. `url` will take
+    #   precedence over `json`
+    def create(url: nil, json: nil, module_name:, options: {})
+      check_args!(url: url, json: json)
+      
+      Service.create(url: url, json: json, module_name: module_name, options: options)
+    end
+
+    def check_args!(url:, json:)
+      raise ArgumentError, "Must provide a URL or JSON argument" unless url || json
+      URI.parse url if url
+      JSON.parse json if json
+    end
   end
 end

--- a/lib/svelte/configuration.rb
+++ b/lib/svelte/configuration.rb
@@ -2,13 +2,14 @@ module Svelte
   # Holds miscelanious configuration options for the current
   # Swagger API specification
   class Configuration
-    attr_reader :host, :base_path, :protocol
+    attr_reader :host, :base_path, :protocol, :middleware_stack
     # Creates a new Configuration instance
     # @param options [Hash] configuration options
     def initialize(options:)
-      @host = options[:host]
-      @base_path = options[:base_path]
-      @protocol = options[:protocol] || default_protocol
+      @host       = options[:host]
+      @base_path  = options[:base_path]
+      @middleware_stack = options[:middleware_stack] || []
+      @protocol   = options[:protocol] || default_protocol
     end
 
     private

--- a/lib/svelte/operation_builder.rb
+++ b/lib/svelte/operation_builder.rb
@@ -15,7 +15,7 @@ module Svelte
             path: operation.path,
             configuration: configuration,
             parameters: builder.request_parameters(full_parameters: parameters),
-            options: builder.options(full_parameters: parameters))
+            options: builder.options(full_parameters: parameters, middleware_stack: configuration.middleware_stack))
         end
       end
 
@@ -39,8 +39,10 @@ module Svelte
       #   method call
       # @return [Hash] Hash with all the options to be sent as part of the
       #   request
-      def options(full_parameters:)
-        full_parameters[1] || {}
+      def options(full_parameters:, middleware_stack:)
+        options = full_parameters[1] || {}
+        options[:middleware_stack] ||= middleware_stack
+        options
       end
     end
   end

--- a/lib/svelte/service.rb
+++ b/lib/svelte/service.rb
@@ -17,6 +17,8 @@ module Svelte
       # @note Either `url` or `json` need to be provided. `url` will take
       #   precedence over `json`
       def create(url: nil, json: nil, module_name:, options: {})
+        Svelte.check_args!(url: url, json: json)
+
         json = get_json(url: url) if url
         SwaggerBuilder.new(raw_hash: JSON.parse(json.to_s),
                            module_name: module_name,

--- a/lib/svelte/swagger_builder.rb
+++ b/lib/svelte/swagger_builder.rb
@@ -51,12 +51,12 @@ module Svelte
 
     private
 
-    def build_configuration(_options)
+    def build_configuration(extra_options)
       options = {
-          host: host,
-          base_path: base_path,
-          protocol: _options[:protocol]
-      }
+        host: host,
+        base_path: base_path,
+      }.merge(extra_options)
+
       Configuration.new(options: options)
     end
 

--- a/spec/lib/svelte/operation_builder_spec.rb
+++ b/spec/lib/svelte/operation_builder_spec.rb
@@ -20,6 +20,7 @@ describe Svelte::OperationBuilder do
     double(:configuration,
            host: host,
            base_path: base_path,
+           middleware_stack: [],
            protocol: protocol)
   end
 
@@ -46,7 +47,7 @@ describe Svelte::OperationBuilder do
         path: path,
         configuration: configuration,
         parameters: { 'request_parameter' => request_parameter },
-        options: {})
+        options: {middleware_stack: []})
 
       module_constant.public_send(method_name, parameters)
     end
@@ -84,7 +85,8 @@ describe Svelte::OperationBuilder do
         path: path,
         configuration: configuration,
         parameters: {},
-        options: {})
+        options: {middleware_stack: []}
+      )
 
       module_constant.public_send(method_name)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ SimpleCov.start
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'svelte'
+require 'byebug'
 require 'json'
 require 'webmock/rspec'
 

--- a/svelte.gemspec
+++ b/svelte.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'typhoeus', '~> 1.0'
 
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'byebug'
+  spec.add_development_dependency 'faraday-http-cache'
   spec.add_development_dependency 'redcarpet', '~> 3.3'
   spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'simplecov', '~> 0.11'


### PR DESCRIPTION
@bernat might be the best for reviewing this.

I'm not completely happy with this approach as it feels like I had to touch too many places, but functionality-wise it serves the purpose.

This allows us to do

``` ruby
middleware_stack = [[Faraday::HttpCache, {cache: Rails.cache}]]

Svelte.create(json: json, module_name: module_name, 
  options: {middleware_stack: middleware_stack}
)

```
