### PR TITLE
allow path params to be in the middle of the url

### DIFF
--- a/lib/svelte/generic_operation.rb
+++ b/lib/svelte/generic_operation.rb
@@ -26,29 +26,26 @@ module Svelte
       private
 
       def url_for(configuration:, path:, parameters:)
-        url_path =
-          [
-            path.non_parameter_elements,
-            named_parameters(path: path, parameters: parameters)
-          ].flatten.join('/')
-
+        url_path = url_path(path: path, parameters: parameters)
         protocol = configuration.protocol
         host = configuration.host
         base_path = configuration.base_path
         if base_path == '/'
           base_path = ''
         end
-        "#{protocol}://#{host}#{base_path}/#{url_path}"
+        "#{protocol}://#{host}#{base_path}#{url_path}"
       end
 
-      def named_parameters(path:, parameters:)
-        path.parameter_elements.map do |parameter_element|
-          unless parameters.key?(parameter_element)
-            raise ParameterError,
-                 "Required parameter `#{parameter_element}` missing"
+      def url_path(path:, parameters:)
+        url_path = path.path.dup
+        path.parameter_elements.each do |parameter_element|
+          if parameters.key?(parameter_element)
+            url_path.sub!("{#{parameter_element}}", parameters[parameter_element].to_s)
+          else
+            raise ParameterError, "Required parameter `#{parameter_element}` missing"
           end
-          parameters[parameter_element]
         end
+        url_path
       end
 
       def clean_parameters(path:, parameters:)

--- a/lib/svelte/path.rb
+++ b/lib/svelte/path.rb
@@ -1,7 +1,7 @@
 module Svelte
   # Describes a Swagger API Path
   class Path
-    attr_reader :non_parameter_elements, :parameter_elements
+    attr_reader :path, :non_parameter_elements, :parameter_elements
 
     # Creates a new Path.
     # @param path [String] path i.e. `'/store/inventory'`

--- a/lib/svelte/version.rb
+++ b/lib/svelte/version.rb
@@ -1,4 +1,4 @@
 module Svelte
   # Version
-  VERSION = '0.1.3'.freeze
+  VERSION = '0.1.4'.freeze
 end

--- a/spec/lib/svelte/generic_operation_spec.rb
+++ b/spec/lib/svelte/generic_operation_spec.rb
@@ -4,8 +4,8 @@ describe Svelte::GenericOperation do
   let(:verb) { :get }
   let(:path) do
     double(:path,
-           parameter_elements: parameter_elements,
-           non_parameter_elements: non_parameter_elements)
+           path: url_path,
+           parameter_elements: parameter_elements)
   end
   let(:base_path) { '/' }
   let(:host) { 'localhost' }
@@ -20,35 +20,63 @@ describe Svelte::GenericOperation do
   end
 
   context '#call' do
-    context 'with url parameters' do
-      let(:parameter_elements) { ['petId'] }
-      let(:non_parameter_elements) { ['pet'] }
-      let(:params) { {} }
+    context 'with url parameter' do
+      context 'at the end of the url' do
+        let(:url_path) { '/pet/{petId}' }
+        let(:parameter_elements) { ['petId'] }
+        let(:params) { {} }
 
-      let(:parameters) do
-        {
-          'petId' => pet_id
-        }
+        let(:parameters) do
+          {
+            'petId' => pet_id
+          }
+        end
+        let(:pet_id) { 1 }
+        let(:url) { "http://localhost/pet/#{pet_id}" }
+
+        it 'calls Svelte::RestClient with the correct parameters' do
+          expect(Svelte::RestClient).to receive(:call).with(verb: verb,
+                                                            url: url,
+                                                            params: params,
+                                                            options: options)
+          described_class.call(verb: verb,
+                               path: path,
+                               configuration: configuration,
+                               parameters: parameters,
+                               options: options)
+        end
       end
-      let(:pet_id) { 1 }
-      let(:url) { "http://localhost/pet/#{pet_id}" }
 
-      it 'calls Svelte::RestClient with the correct parameters' do
-        expect(Svelte::RestClient).to receive(:call).with(verb: verb,
-                                                          url: url,
-                                                          params: params,
-                                                          options: options)
-        described_class.call(verb: verb,
-                             path: path,
-                             configuration: configuration,
-                             parameters: parameters,
-                             options: options)
+      context 'not at the end of the url' do
+        let(:url_path) { '/pet/{petId}/hobbies' }
+        let(:parameter_elements) { ['petId'] }
+        let(:params) { {} }
+
+        let(:parameters) do
+          {
+              'petId' => pet_id
+          }
+        end
+        let(:pet_id) { 1 }
+        let(:url) { "http://localhost/pet/#{pet_id}/hobbies" }
+
+        it 'calls Svelte::RestClient with the correct parameters' do
+          expect(Svelte::RestClient).to receive(:call).with(verb: verb,
+                                                            url: url,
+                                                            params: params,
+                                                            options: options)
+          described_class.call(verb: verb,
+                               path: path,
+                               configuration: configuration,
+                               parameters: parameters,
+                               options: options)
+        end
       end
     end
 
     context 'without url parameters' do
+      let(:url_path) { '/pet' }
       let(:parameter_elements) { [] }
-      let(:non_parameter_elements) { ['pet'] }
       let(:params) { parameters }
       let(:parameters) do
         {
@@ -72,8 +100,8 @@ describe Svelte::GenericOperation do
     end
 
     context 'with missing url parameters' do
+      let(:url_path) { '/pet/{petId}' }
       let(:parameter_elements) { ['petId'] }
-      let(:non_parameter_elements) { ['pet'] }
 
       it 'raises a Svelte::ParameterError exception' do
         expect do


### PR DESCRIPTION
This commit will allow svelte to work with urls that have params that are not at the end of the URL e.g.:

`/api/pets/{petId}/hobbies`