### PR TITLE
Request options & headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,41 @@ view.valid? # true
 view.as_json # {:currencyCode=>"GBP", :amount=>40.0}
 ```
 
-### Options
+### Service Options
+
+When creating a client from the API spec, you can pass an `options` hash that will determine how the HTTP client interacts with your service.
+
+```ruby
+Svelte::Service.create(
+  url: "http://path/to/swagger/spec/resource.json",
+  module_name: 'PetStore', 
+  options: {
+    host: 'somehost.com',
+    base_path: '/api/v1',
+    protocol: 'https',
+    auth: {
+      basic: {
+        username: "user",
+        password: "pass"
+      }
+    },
+    headers: {
+      runas: 'otheruser'
+    }
+  })
+```
+
+The available options are:
+- `host` : overrides the `host` value found in the Swagger API spec, used when making API requests
+- `base_path` : overrides the `basePath` value found in the Swagger API spec, used when making API requests
+- `protocol` : overrides the network protocol used (default value is "http" when not present)
+- `auth` : sets optional authorization headers.  Possible values:
+  - `{ basic: { username: "value", password: "value" } }` : sets basic authentication credentials
+  - `{ token: "Bearer 12345" }` : sets a generic Authorization header (in this case a Bearer token `12345`)
+- `headers` : a collection of arbitrary key/value pairs converted to HTTP request headers included with each outgoing request
+
+
+### Request Options
 
 You can specify a timeout option on a per request basis. If the request times out a `Svelte::TimeoutError` exception
 will be raised.

--- a/lib/svelte.rb
+++ b/lib/svelte.rb
@@ -29,6 +29,13 @@ module Svelte
   # @param json [String] the entire Swagger spec as a String
   # @param module_name [String] constant name where you want Svelte to build
   #   the new functionality on top of
+  # @param options [Hash] configuration options when making HTTP requests
+  #   Supported values are:
+  #     :auth [Hash] either { token: "value" } or { basic: { username: "value", password: "value" }}
+  #     :headers [Hash] HTTP request headers
+  #     :host [String] overrides the "host" value in the Swagger spec
+  #     :base_path [String] overrides the "basePath" value in the Swagger spec
+  #     :protocol [String] overrides the network protocol used (defaults to "http")
   # @note Either `url` or `json` need to be provided. `url` will take
   #   precedence over `json`
   def self.create(url: nil, json: nil, module_name:, options: {})

--- a/lib/svelte/configuration.rb
+++ b/lib/svelte/configuration.rb
@@ -2,13 +2,14 @@ module Svelte
   # Holds miscelanious configuration options for the current
   # Swagger API specification
   class Configuration
-    attr_reader :host, :base_path, :protocol
+    attr_reader :host, :base_path, :protocol, :headers
     # Creates a new Configuration instance
     # @param options [Hash] configuration options
     def initialize(options:)
       @host = options[:host]
       @base_path = options[:base_path]
       @protocol = options[:protocol] || default_protocol
+      @headers = options[:headers]
     end
 
     private

--- a/lib/svelte/generic_operation.rb
+++ b/lib/svelte/generic_operation.rb
@@ -17,10 +17,12 @@ module Svelte
                       parameters: parameters)
         request_parameters = clean_parameters(path: path,
                                               parameters: parameters)
+        request_options = build_options(configuration: configuration, 
+                                        options: options)
         RestClient.call(verb: verb,
                         url: url,
                         params: request_parameters,
-                        options: options)
+                        options: request_options)
       end
 
       private
@@ -54,6 +56,14 @@ module Svelte
           clean_parameters.delete(parameter_element)
         end
         clean_parameters
+      end
+
+      def build_options(configuration:, options:)
+        if configuration.headers
+          return (options || {}).merge({ headers: configuration.headers })
+        end
+
+        options
       end
     end
   end

--- a/lib/svelte/generic_operation.rb
+++ b/lib/svelte/generic_operation.rb
@@ -17,8 +17,8 @@ module Svelte
                       parameters: parameters)
         request_parameters = clean_parameters(path: path,
                                               parameters: parameters)
-        request_options = build_options(configuration: configuration, 
-                                        options: options)
+        request_options = build_request_options(configuration: configuration, 
+                                                options: options)
         RestClient.call(verb: verb,
                         url: url,
                         params: request_parameters,
@@ -58,8 +58,8 @@ module Svelte
         clean_parameters
       end
 
-      def build_options(configuration:, options:)
-        if configuration.headers
+      def build_request_options(configuration:, options:)
+        if configuration.headers && configuration.headers.any?
           return (options || {}).merge({ headers: configuration.headers })
         end
 

--- a/lib/svelte/rest_client.rb
+++ b/lib/svelte/rest_client.rb
@@ -21,6 +21,7 @@ module Svelte
       def call(verb:, url:, params: {}, options: {})
         connection.send verb, url, params do |request|
           request.options.timeout = options[:timeout] if options[:timeout]
+          options[:headers].each { |key, value| request.headers[key] = value } if options[:headers]
         end
       rescue Faraday::TimeoutError => e
         raise HTTPError.new(parent: e)

--- a/lib/svelte/service.rb
+++ b/lib/svelte/service.rb
@@ -1,3 +1,5 @@
+require 'base64'
+
 module Svelte
   # Dynamically generates a client to consume a Swagger API
   class Service
@@ -7,6 +9,9 @@ module Svelte
       # @param json [String] full Swagger API spec as a String
       # @param module_name [String] constant name where Svelte will
       #   build the functionality on top of
+      # @param options [Hash] options passed as configuration to the 
+      #   generated Swagger objects.  :auth options will also be
+      #   used here when making the initial Swagger spec request.
       # @return [Module] A newly created `Module` with the
       #   module hierarchy and methods to consume the Swagger API
       #   The new module will be built on top of `Svelte::Service` and will
@@ -17,21 +22,47 @@ module Svelte
       # @note Either `url` or `json` need to be provided. `url` will take
       #   precedence over `json`
       def create(url: nil, json: nil, module_name:, options: {})
-        json = get_json(url: url) if url
+        options_with_auth = configure_auth_options(options: options)
+        json = get_json(url: url, options: options_with_auth) if url
         SwaggerBuilder.new(raw_hash: JSON.parse(json.to_s),
                            module_name: module_name,
-                           options: options).make_resource
+                           options: options_with_auth).make_resource
       end
 
       private
 
-      def get_json(url:)
-        Faraday.get(url).body
+      def get_json(url:, options:)
+        create_connection(url: url, options: options).get.body
       rescue Faraday::ClientError => e
         raise HTTPError.new(
           message: "Could not get API json from #{url}",
           parent: e
         )
+      end
+
+      def configure_auth_options(options:)
+        options[:headers] ||= {}
+
+        auth = options.delete(:auth)
+
+        if auth
+          basic = auth.delete(:basic)
+          token = auth.delete(:token)
+          
+          if basic
+            options[:headers]["Authorization"] = "Basic #{Base64.encode64([basic[:username], basic[:password]].join(':'))}"
+          elsif token
+            options[:headers]["Authorization"] = token
+          end
+        end
+
+        options
+      end
+
+      def create_connection(url:, options:)
+        connection = Faraday.new(url: url)
+        options[:headers].each { |key, value| connection.headers[key] = value }
+        connection
       end
     end
   end

--- a/lib/svelte/service.rb
+++ b/lib/svelte/service.rb
@@ -24,6 +24,7 @@ module Svelte
       def create(url: nil, json: nil, module_name:, options: {})
         options_with_auth = configure_auth_options(options: options)
         json = get_json(url: url, options: options_with_auth) if url
+
         SwaggerBuilder.new(raw_hash: JSON.parse(json.to_s),
                            module_name: module_name,
                            options: options_with_auth).make_resource
@@ -50,7 +51,12 @@ module Svelte
           token = auth.delete(:token)
           
           if basic
-            options[:headers]["Authorization"] = "Basic #{Base64.encode64([basic[:username], basic[:password]].join(':'))}"
+            token = Base64.encode64([
+              basic[:username], 
+              basic[:password]
+            ].join(':')).chomp
+            
+            options[:headers]["Authorization"] = "Basic #{token}"
           elsif token
             options[:headers]["Authorization"] = token
           end

--- a/lib/svelte/swagger_builder.rb
+++ b/lib/svelte/swagger_builder.rb
@@ -7,7 +7,7 @@ module Svelte
     # @param raw_hash [Hash] Swagger API definition
     # @param module_name [String] name of the constant you want built
     # @param options [Hash] Swagger API options. It will be used to build the
-    #   [Configuration]. Supports the `:host` value for now.
+    #   [Configuration]. Supported values: ":host", ":base_path", ":protocol", ":headers"
     def initialize(raw_hash:, module_name:, options:)
       @raw_hash = raw_hash
       @module_name = module_name
@@ -53,9 +53,10 @@ module Svelte
 
     def build_configuration(_options)
       options = {
-          host: host,
-          base_path: base_path,
-          protocol: _options[:protocol]
+          host: _options[:host] || host,
+          base_path: _options[:base_path] || base_path,
+          protocol: _options[:protocol],
+          headers: _options[:headers] || {}
       }
       Configuration.new(options: options)
     end

--- a/lib/svelte/swagger_builder.rb
+++ b/lib/svelte/swagger_builder.rb
@@ -1,17 +1,19 @@
 module Svelte
   # Dynamically builds Swagger API paths and operations on top of a given module
   class SwaggerBuilder
-    attr_reader :raw_hash, :module_name, :configuration
+    attr_reader :raw_hash, :module_name, :configuration, :headers
 
     # Creates a new SwaggerBuilder
     # @param raw_hash [Hash] Swagger API definition
     # @param module_name [String] name of the constant you want built
     # @param options [Hash] Swagger API options. It will be used to build the
-    #   [Configuration]. Supported values: ":host", ":base_path", ":protocol", ":headers"
-    def initialize(raw_hash:, module_name:, options:)
+    #   [Configuration]. Supported values: ":host", ":base_path", ":protocol"
+    # @param headers [Hash] REST client HTTP request headers
+    def initialize(raw_hash:, module_name:, options:, headers:)
       @raw_hash = raw_hash
       @module_name = module_name
-      @configuration = build_configuration(options)
+      @configuration = build_configuration(options, headers)
+      @headers = headers
       validate
     end
 
@@ -51,12 +53,12 @@ module Svelte
 
     private
 
-    def build_configuration(_options)
+    def build_configuration(_options, headers)
       options = {
           host: _options[:host] || host,
           base_path: _options[:base_path] || base_path,
           protocol: _options[:protocol],
-          headers: _options[:headers] || {}
+          headers: headers || {}
       }
       Configuration.new(options: options)
     end

--- a/spec/lib/svelte/generic_operation_spec.rb
+++ b/spec/lib/svelte/generic_operation_spec.rb
@@ -10,13 +10,15 @@ describe Svelte::GenericOperation do
   let(:base_path) { '/' }
   let(:host) { 'localhost' }
   let(:parameters) { {} }
-  let(:options) { {} }
+  let(:options) { { headers: { test: "value" } } }
   let(:protocol) { 'http' }
+  let(:headers) { { test: 'value' } }
   let(:configuration) do
     double(:configuration,
            host: host,
            base_path: base_path,
-           protocol: protocol)
+           protocol: protocol,
+           headers: headers)
   end
 
   context '#call' do

--- a/spec/lib/svelte/rest_client_spec.rb
+++ b/spec/lib/svelte/rest_client_spec.rb
@@ -19,7 +19,7 @@ describe Svelte::RestClient do
 
     described_class.call(verb: verb, url: test_url, options: { 
       headers: { 
-        'Test': 'value', 
+        'Test' => 'value', 
         'Other' => 'value2' 
       } 
     })

--- a/spec/lib/svelte/rest_client_spec.rb
+++ b/spec/lib/svelte/rest_client_spec.rb
@@ -13,6 +13,23 @@ describe Svelte::RestClient do
       .to be_an_instance_of(Faraday::Response)
   end
 
+  it 'should set optional headers' do
+    stub_request(verb, test_url)
+      .to_return(status: 404, body: '')
+
+    described_class.call(verb: verb, url: test_url, options: { 
+      headers: { 
+        'Test': 'value', 
+        'Other' => 'value2' 
+      } 
+    })
+
+    assert_requested(:any, test_url, headers: { 
+      test: 'value', 
+      other: 'value2' 
+    })
+  end
+
   context 'when the remote service is very slow' do
     before do
       stub_request(verb, test_url)

--- a/spec/lib/svelte_spec.rb
+++ b/spec/lib/svelte_spec.rb
@@ -74,21 +74,64 @@ describe Svelte do
 
     context 'with an online json' do
       let(:url) { 'http://www.example.com/petstore.json' }
+      
+      context 'with default options' do
+        before do
+          stub_request(:any, url)
+            .to_return(body: json, status: 200)
 
-      before do
-        stub_request(:any, url)
-          .to_return(body: json, status: 200)
+          described_class.create(url: url, module_name: module_name)
+        end
 
-        described_class.create(url: url, module_name: module_name)
+        include_examples 'builds all the things'
+
+        it 'raises a Svelte::HTTPException on http errors' do
+          stub_request(:any, url).to_timeout
+
+          expect { described_class.create(url: url, module_name: module_name, options: options) }
+            .to raise_error(Svelte::HTTPError, "Could not get API json from #{url}")
+        end
       end
 
-      include_examples 'builds all the things'
+      context 'with a bearer token' do
+        it 'sets the correct headers' do
+          stub_request(:any, url)
+            .to_return(body: json, status: 200)
+  
+          described_class.create(url: url, module_name: module_name, options: {
+            auth: { token: 'Bearer 12345' }
+          })
+    
+          assert_requested(:any, url, headers: { 'Authorization' => 'Bearer 12345' })
+        end
+      end
 
-      it 'raises a Svelte::HTTPException on http errors' do
-        stub_request(:any, url).to_timeout
+      context 'with basic authentication' do
+        let(:url_with_auth) { 'http://user:pass@www.example.com/petstore.json' }
+        
+        it 'sets the correct headers' do
+          stub_request(:any, url_with_auth)
+            .to_return(body: json, status: 200)
+  
+          described_class.create(url: url, module_name: module_name, options: {
+            auth: { basic: { username: 'user', password: 'pass' } }
+          })
+  
+          assert_requested(:any, url_with_auth)
+        end
+      end
 
-        expect { described_class.create(url: url, module_name: module_name, options: options) }
-          .to raise_error(Svelte::HTTPError, "Could not get API json from #{url}")
+      context 'with arbitrary headers' do
+        it 'sets the correct headers' do
+          stub_request(:any, url)
+            .to_return(body: json, status: 200)
+  
+          described_class.create(url: url, module_name: module_name, options: {
+            headers: { test: 'value' }
+          })
+  
+          assert_requested(:any, url, headers: { 'test' => 'value' })
+        end
       end
     end
 


### PR DESCRIPTION
This pull request adds support for several new options for overriding request behavior (all contained within the `Svelte.create(option:)` hash):

1. Authentication headers, either basic auth or a regular `Authorization` header token
2. Generic HTTP headers
3. Override the request `host` and `base_path` (in addition to the existing `protocol` option)

The authentication and headers will also be included in the initial HTTP request when fetching the service JSON definition via `Svelte.create(url:)`.

I realized after opening this PR that there is some overlap with #10 , although I believe having separate `auth` options feels nicer, and I personally needed a way to override `host` for my own uses.