### PR TITLE
Allow Ruby 3.0

### DIFF
--- a/svelte.gemspec
+++ b/svelte.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency 'faraday', '~> 0.9'
   spec.add_dependency 'faraday_middleware', '~> 0.10'


### PR DESCRIPTION
The gemspec specifies the Ruby version as '~> 2.4', which prevents the gem from installing on Ruby 3.0. However, the gem works fine on 3.0 if the version spec is relaxed.